### PR TITLE
Sugar Pond CAS -> Intercode OAuth2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,10 @@ gem 'minipack'
 gem 'listen'
 
 gem 'devise', '~> 4.8.0'
-gem 'devise_cas_authenticatable', '~> 2.0.0.alpha1'
 gem 'rack-cas'
 gem 'cancancan'
+gem 'intercode_client'
+gem 'omniauth-rails_csrf_protection'
 
 gem 'net-pop'
 gem 'net-smtp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       activerecord (>= 4.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.494.0)
@@ -105,6 +106,7 @@ GEM
     backport (1.2.0)
     bcrypt (3.1.16)
     benchmark (0.1.1)
+    bindata (2.4.10)
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.3.0)
@@ -124,9 +126,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise_cas_authenticatable (2.0.0.alpha1)
-      devise (>= 4.0.0)
-      rack-cas
     diff-lcs (1.4.4)
     digest (3.1.0)
     dotenv (2.7.6)
@@ -140,6 +139,10 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (2.3.0)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.3)
     ffi (1.15.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -147,6 +150,9 @@ GEM
       railties
       sprockets-rails
     graphql (1.12.16)
+    graphql-client (0.18.0)
+      activesupport (>= 3.0)
+      graphql
     graphql-rails_logger (1.2.3)
       actionpack (> 5.0)
       activesupport (> 5.0)
@@ -155,11 +161,21 @@ GEM
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
+    hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    intercode_client (0.1.1)
+      graphql-client
+      json-jwt
+      omniauth-oauth2
     io-wait (0.2.1)
     jaro_winkler (1.5.4)
     jmespath (1.4.0)
+    json-jwt (1.13.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+    jwt (2.3.0)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -180,6 +196,8 @@ GEM
       actionview
       railties (>= 4.2)
     minitest (5.15.0)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -199,6 +217,22 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    oauth2 (1.4.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (2.1.0)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.7.2)
+      oauth2 (~> 1.4)
+      omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.2.0)
@@ -226,6 +260,8 @@ GEM
       addressable (~> 2.3)
       nokogiri (~> 1.5)
       rack (>= 1.3)
+    rack-protection (2.2.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.6)
@@ -289,6 +325,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     solargraph (0.43.0)
       backport (~> 1.2)
       benchmark
@@ -348,17 +385,18 @@ DEPENDENCIES
   color
   database_cleaner
   devise (~> 4.8.0)
-  devise_cas_authenticatable (~> 2.0.0.alpha1)
   dotenv-rails
   factory_bot_rails
   graphiql-rails
   graphql
   graphql-rails_logger
+  intercode_client
   listen
   minipack
   net-imap
   net-pop
   net-smtp
+  omniauth-rails_csrf_protection
   pg
   pg_search
   prettier (~> 3.1)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class SessionsController < Devise::CasSessionsController
+class SessionsController < Devise::SessionsController
   prepend_before_action :set_return_to, only: [:new] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   private

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # See https://github.com/omniauth/omniauth/wiki/FAQ#rails-session-is-clobbered-after-callback-on-developer-strategy
+  skip_before_action :verify_authenticity_token, only: :intercode
+
+  def intercode
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    sign_in_and_redirect @user, event: :authentication
+    set_flash_message(:notice, :success, kind: "Intercode") if is_navigational_format?
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/javascript/AppLayout.tsx
+++ b/app/javascript/AppLayout.tsx
@@ -1,19 +1,17 @@
 import { LoadQueryWrapper, PageLoadingIndicator } from '@neinteractiveliterature/litform';
 import { ReactNode, Suspense } from 'react';
 import { Link } from 'react-router-dom';
-import {
-  AppLayoutQueryData,
-  AppLayoutQueryVariables,
-  useAppLayoutQuery,
-} from './queries.generated';
+import { AppLayoutQueryData, AppLayoutQueryVariables, useAppLayoutQuery } from './queries.generated';
 
 export type AppLayoutProps = {
   children: ReactNode;
+  signInCSRFToken: string;
+  signOutCSRFToken: string;
 };
 
 export default LoadQueryWrapper<AppLayoutQueryData, AppLayoutQueryVariables, AppLayoutProps>(
   useAppLayoutQuery,
-  function AppLayout({ data, children }) {
+  function AppLayout({ data, children, signInCSRFToken, signOutCSRFToken }) {
     return (
       <>
         <div className="container">
@@ -73,9 +71,20 @@ export default LoadQueryWrapper<AppLayoutQueryData, AppLayoutQueryVariables, App
                   </li>
                   <li>
                     {data.currentUser ? (
-                      <a href="/users/sign_out">Sign out</a>
+                      <form action="/users/sign_out" method="POST">
+                        <input type="hidden" name="_method" value="DELETE" />
+                        <input type="hidden" name="authenticity_token" value={signOutCSRFToken} />
+                        <button type="submit" className="btn btn-link">
+                          Sign out
+                        </button>
+                      </form>
                     ) : (
-                      <a href="/users/sign_in">Sign in</a>
+                      <form action="/users/auth/intercode" method="POST">
+                        <input type="hidden" name="authenticity_token" value={signInCSRFToken} />
+                        <button className="btn btn-link" type="submit">
+                          Sign in
+                        </button>
+                      </form>
                     )}
                   </li>
                 </ul>
@@ -83,20 +92,14 @@ export default LoadQueryWrapper<AppLayoutQueryData, AppLayoutQueryVariables, App
             </ul>
           </nav>
 
-          <Suspense fallback={<PageLoadingIndicator visible iconSet="bootstrap-icons" />}>
-            {children}
-          </Suspense>
+          <Suspense fallback={<PageLoadingIndicator visible iconSet="bootstrap-icons" />}>{children}</Suspense>
 
           <nav>
             <ul className="list-inline" style={{ textAlign: 'center' }}>
               <li className="list-inline-item">
                 <small>
                   Larp Library &copy; 2015-{new Date().getFullYear()}{' '}
-                  <a
-                    href="http://interactiveliterature.org"
-                    target="_blank"
-                    rel="noreferrer noopener"
-                  >
+                  <a href="http://interactiveliterature.org" target="_blank" rel="noreferrer noopener">
                     New England Interactive Literature
                   </a>
                 </small>

--- a/app/javascript/AppRoot.tsx
+++ b/app/javascript/AppRoot.tsx
@@ -12,32 +12,23 @@ const PageComponentImports: {
   BrandPage: () => import(/* webpackChunkName: "BrandPage" */ './Brands/BrandPage'),
   BrandListPage: () => import(/* webpackChunkName: "BrandListPage" */ './Brands/BrandListPage'),
   EditBrandPage: () => import(/* webpackChunkName: "EditBrandPage" */ './Brands/EditBrandPage'),
-  EditProjectPage: () =>
-    import(/* webpackChunkName: "EditProjectPage" */ './Project/EditProjectPage'),
+  EditProjectPage: () => import(/* webpackChunkName: "EditProjectPage" */ './Project/EditProjectPage'),
   EditTagPage: () => import(/* webpackChunkName: "EditTagPage" */ './Tags/EditTagPage'),
   EditTagCategoryPage: () =>
     import(/* webpackChunkName: "EditTagCategoryPage" */ './TagCategories/EditTagCategoryPage'),
-  LicensingPage: () =>
-    import(/* webpackChunkName: "LicensingPage" */ './StaticPages/LicensingPage'),
+  LicensingPage: () => import(/* webpackChunkName: "LicensingPage" */ './StaticPages/LicensingPage'),
   NewBrandPage: () => import(/* webpackChunkName: "NewBrandPage" */ './Brands/NewBrandPage'),
   NewProjectPage: () => import(/* webpackChunkName: "NewProjectPage" */ './Project/NewProjectPage'),
   NewTagPage: () => import(/* webpackChunkName: "NewTagPage" */ './Tags/NewTagPage'),
-  NewTagCategoryPage: () =>
-    import(/* webpackChunkName: "NewTagCategoryPage" */ './TagCategories/NewTagCategoryPage'),
+  NewTagCategoryPage: () => import(/* webpackChunkName: "NewTagCategoryPage" */ './TagCategories/NewTagCategoryPage'),
   HomePage: () => import(/* webpackChunkName: "HomePage" */ './HomePage/HomePage'),
-  InvitationPage: () =>
-    import(/* webpackChunkName: "InvitationPage" */ './Invitations/InvitationPage'),
+  InvitationPage: () => import(/* webpackChunkName: "InvitationPage" */ './Invitations/InvitationPage'),
   ProjectInitialContentPage: () =>
-    import(
-      /* webpackChunkName: "ProjectInitialContentPage" */ './Project/ProjectInitialContentPage'
-    ),
+    import(/* webpackChunkName: "ProjectInitialContentPage" */ './Project/ProjectInitialContentPage'),
   ProjectPromotionsPage: () =>
-    import(
-      /* webpackChunkName: "ProjectPromotionsPage" */ './ProjectPromotions/ProjectPromotionsPage'
-    ),
+    import(/* webpackChunkName: "ProjectPromotionsPage" */ './ProjectPromotions/ProjectPromotionsPage'),
   ProjectPage: () => import(/* webpackChunkName: "ProjectPage" */ './Project/ProjectPage'),
-  ProjectSearchPage: () =>
-    import(/* webpackChunkName: "ProjectSearchPage" */ './ProjectSearch/ProjectSearchPage'),
+  ProjectSearchPage: () => import(/* webpackChunkName: "ProjectSearchPage" */ './ProjectSearch/ProjectSearchPage'),
   TagListPage: () => import(/* webpackChunkName: "TagListPage" */ './Tags/TagListPage'),
   TagCategoryListPage: () =>
     import(/* webpackChunkName: "TagCategoryListPage" */ './TagCategories/TagCategoryListPage'),
@@ -45,18 +36,18 @@ const PageComponentImports: {
     import(/* webpackChunkName: "UnapprovedBrandsListPage" */ './Brands/UnapprovedBrandsListPage'),
 };
 
-const PageComponents = mapValues(PageComponentImports, (importFunction) =>
-  React.lazy(importFunction),
-);
+const PageComponents = mapValues(PageComponentImports, (importFunction) => React.lazy(importFunction));
 
 export type AppRootProps = {
   s3Configuration: S3ConfigurationContextValue;
+  signInCSRFToken: string;
+  signOutCSRFToken: string;
 };
 
-function AppRoot({ s3Configuration }: AppRootProps): JSX.Element {
+function AppRoot({ s3Configuration, signInCSRFToken, signOutCSRFToken }: AppRootProps): JSX.Element {
   return (
     <S3ConfigurationContext.Provider value={s3Configuration}>
-      <AppLayout>
+      <AppLayout signInCSRFToken={signInCSRFToken} signOutCSRFToken={signOutCSRFToken}>
         <Routes>
           <Route path="projects" element={<PageComponents.ProjectSearchPage />} />
 
@@ -65,17 +56,11 @@ function AppRoot({ s3Configuration }: AppRootProps): JSX.Element {
             <Route path="new" element={<PageComponents.NewBrandPage />} />
 
             <Route path=":brandSlug/*">
-              <Route
-                path="invitations/:invitationToken"
-                element={<PageComponents.InvitationPage />}
-              />
+              <Route path="invitations/:invitationToken" element={<PageComponents.InvitationPage />} />
               <Route path="edit" element={<PageComponents.EditBrandPage />} />
               <Route path="projects/*">
                 <Route path=":projectId/edit" element={<PageComponents.EditProjectPage />} />
-                <Route
-                  path=":projectId/initial_content"
-                  element={<PageComponents.ProjectInitialContentPage />}
-                />
+                <Route path=":projectId/initial_content" element={<PageComponents.ProjectInitialContentPage />} />
                 <Route path=":projectId" element={<PageComponents.ProjectPage />} />
                 <Route path="new" element={<PageComponents.NewProjectPage />} />
               </Route>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class User < ApplicationRecord
-  devise :cas_authenticatable, :trackable
+  devise :omniauthable, :trackable, omniauth_providers: %i[intercode]
 
   has_many :brand_memberships, dependent: :destroy
   has_many :brands, through: :brand_memberships
@@ -9,16 +9,18 @@ class User < ApplicationRecord
     "#{firstname} #{lastname}"
   end
 
-  def cas_extra_attributes=(extra_attributes)
-    extra_attributes.each do |name, value|
-      case name.to_sym
-      when :firstname
-        self.firstname = value
-      when :lastname
-        self.lastname = value
-      when :email
-        self.email = value
-      end
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create! do |user|
+      user.email = auth.info.email
+      user.firstname = auth.info.first_name
+      user.lastname = auth.info.last_name
+    end
+  end
+
+  def self.new_with_session(params, session)
+    super.tap do |user|
+      data = session["devise.intercode_data"]
+      user.email = data["email"] if data && data["extra"]["raw_info"] && user.email.blank?
     end
   end
 end

--- a/app/views/single_page_app/show.html.erb
+++ b/app/views/single_page_app/show.html.erb
@@ -3,5 +3,7 @@
   s3Configuration: {
     awsAccessKeyId: ENV['AWS_ACCESS_KEY_ID'],
     bucketName: (ENV['AWS_S3_BUCKET'] || "larp-library-#{Rails.env}")
-  }
+  },
+  signInCSRFToken: form_authenticity_token(form_options: { action: '/users/auth/intercode', method: 'POST' }),
+  signOutCSRFToken: form_authenticity_token(form_options: { action: '/'})
 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,9 +25,6 @@ module LarpLibrary
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
-    config.rack_cas.server_url = "https://accounts.sugarpond.net/cas"
-    config.rack_cas.service = "/users/service"
-
     config.middleware.use Rack::Deflater
 
     # we use generated columns, which the Ruby schema format doesn't support

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
+
+require "omniauth/strategies/intercode"
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  config.cas_logout_url_param = "destination"
+  config.omniauth :intercode, ENV["INTERCODE_APP_ID"], ENV["INTERCODE_APP_SECRET"], scope: "public openid"
 
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
@@ -14,7 +17,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "nat@aegames.org"
+  config.mailer_sender = "webmaster@interactiveliterature.org"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,20 +3,13 @@ Rails.application.routes.draw do
   mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql" if Rails.env.development?
   post "/graphql", to: "graphql#execute"
 
-  devise_for :users, controllers: {
-    sessions: "sessions",
-    cas_sessions: "sessions"
-  }
+  devise_for :users, controllers: { sessions: "sessions", omniauth_callbacks: "users/omniauth_callbacks" }
 
-  # Working around Illyan's lack of CORS; we can get rid of this when we switch to Intercode OAuth2
   devise_scope :user do
-    get "/users/sign_out" => "sessions#destroy"
+    delete "/users/sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
   end
 
-  get "/brands/:brand_id/projects/:project_id/project_files/auth_upload" =>
-    "project_files#auth_upload"
+  get "/brands/:brand_id/projects/:project_id/project_files/auth_upload" => "project_files#auth_upload"
 
-  get "/(*extra)" => "single_page_app#show", as: "root", constraints: {
-    extra: %r{(?!(uploads|packs|assets)/).*}
-  }
+  get "/(*extra)" => "single_page_app#show", :as => "root", :constraints => { extra: %r{(?!(uploads|packs|assets)/).*} }
 end

--- a/db/migrate/20220521194451_add_omniauth_to_users.rb
+++ b/db/migrate/20220521194451_add_omniauth_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class AddOmniauthToUsers < ActiveRecord::Migration[6.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :provider
+      t.string :uid
+    end
+
+    add_index :users, %i[provider uid], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -406,7 +406,9 @@ CREATE TABLE public.users (
     current_sign_in_ip character varying,
     last_sign_in_ip character varying,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    provider character varying,
+    uid character varying
 );
 
 
@@ -827,6 +829,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220520003728'),
 ('20220520004351'),
 ('20220520145832'),
-('20220520150212');
+('20220520150212'),
+('20220521194451');
 
 

--- a/lib/tasks/larp_library/migrate_cas_users.rake
+++ b/lib/tasks/larp_library/migrate_cas_users.rake
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+CASMigrationFindUsersByEmailQuery = IntercodeClient::Client.parse <<~GRAPHQL
+  query($email: String!) {
+    users_paginated(filters: { email: $email }) {
+      total_entries
+      entries {
+        id
+        email
+      }
+    }
+  }
+GRAPHQL
+
+# rubocop:disable Metrics/BlockLength
+namespace :larp_library do
+  task migrate_cas_users: :environment do
+    oauth_client =
+      OAuth2::Client.new(
+        ENV.fetch("INTERCODE_MIGRATION_APP_ID"),
+        ENV.fetch("INTERCODE_MIGRATION_APP_SECRET"),
+        site: ENV.fetch("INTERCODE_URL")
+      )
+
+    puts <<~MESSAGE
+    Please go to:
+    #{oauth_client.auth_code.authorize_url(redirect_uri: "urn:ietf:wg:oauth:2.0:oob", scope: "public openid read_organizations")}
+    And enter the code you get:
+    MESSAGE
+
+    code = $stdin.gets.strip
+    token = oauth_client.auth_code.get_token(code, redirect_uri: "urn:ietf:wg:oauth:2.0:oob")
+
+    missing_emails = []
+
+    User
+      .where(uid: nil)
+      .where.not(username: nil)
+      .find_each do |user|
+        puts "Migrating #{user.username}"
+        response =
+          IntercodeClient::Client.query(
+            CASMigrationFindUsersByEmailQuery,
+            variables: {
+              email: user.username
+            },
+            context: {
+              headers: token.headers
+            }
+          )
+
+        possible_users =
+          response.data.users_paginated.entries.select do |intercode_user|
+            intercode_user.email.casecmp(user.username).zero?
+          end
+
+        if possible_users.size != 1
+          puts "WARNING!  Expected 1 user but found #{response.data.users_paginated.total_entries}"
+          missing_emails << user.username if response.data.users_paginated.total_entries.zero?
+          next
+        end
+
+        user.update!(provider: "intercode", uid: response.data.users_paginated.entries.first.to_h["id"])
+      end
+
+    if missing_emails.any?
+      puts
+      puts "Some users could not be imported because their email address didn't exist in Intercode."
+      puts "To fix this, run bin/rails import:illyan ILLYAN_DB_URL=<url here> EMAILS='#{missing_emails.join(" ")}'"
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
The goal is to switch from using Sugar Pond Accounts for authentication over to using Intercode accounts.  There are a few reasons for this:

* Sugar Pond Accounts is CAS-based, whereas Intercode is an OAuth2/OpenID Connect server, which is much better supported in the Ruby ecosystem
* Larp Library is now a NEIL project (actually, it basically has been for most of its life - even though it started as an Alleged Entertainment project, it transferred to NEIL within a few months) and should use a NEIL-controlled authentication server
* Using Intercode for authentication enables some possible future features such as automatically pulling a list of cons where games have run, and/or automatically generating proposals to run Larp Library games at future cons

This is a forward-port of an abandoned feature branch to do this.  We've since extracted a gem from that branch called intercode_client that makes the OAuth client stuff reusable, so this new implementation uses that.  Otherwise, it's very similar to the older one.